### PR TITLE
feat: add Topic to search index

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ import datetime
 import time
 from flask import url_for
 
-from udata_search_service.domain.factories import DatasetFactory, OrganizationFactory, ReuseFactory
+from udata_search_service.domain.factories import DatasetFactory, OrganizationFactory, ReuseFactory, TopicFactory
 
 
 def test_api_dataset_index_unindex(app, client, faker):
@@ -469,6 +469,74 @@ def test_api_dataservice_index_on_another_index(app, client, search_client, fake
 
     resp = search_client.es.get(index=f"{app.config['UDATA_INSTANCE_NAME']}-{index_name}", id=dataservice['id'])
     assert resp['_source']['title'] == dataservice['title']
+
+
+def test_api_topic_index_unindex(client, faker):
+    topic = {
+        'id': faker.md5(),
+        'name': faker.sentence(),
+        'description': faker.text(),
+        'created_at': faker.past_datetime().isoformat(),
+        'last_modified': faker.past_datetime().isoformat(),
+        'featured': faker.boolean(),
+        'organization': {
+            'id': faker.md5(),
+            'name': faker.company(),
+            'public_service': faker.random_int(min=0, max=1),
+            'followers': faker.random_int(),
+            'badges': [faker.word()]
+        },
+        'tags': [faker.word()],
+        'granularity': faker.word(),
+        'geozones': [{'id': faker.word(), 'name': faker.word(), 'keys': [faker.random_int()]},
+                     {'id': faker.word()}],
+        'owner': None,
+        'extras': {},
+    }
+
+    query = {
+        'document': topic,
+        'index': None
+    }
+
+    index_resp = client.post(url_for('api.topic_index'), json={'document': topic, 'index': 'random-non-existing-index'})
+    assert index_resp.status_code == 404
+
+    index_resp = client.post(url_for('api.topic_index'), json=query)
+    assert index_resp.status_code == 200
+
+    time.sleep(2)
+
+    topic_resp = client.get(url_for('api.topic_get_specific', topic_id=topic['id']))
+    assert topic_resp.status_code == 200
+    assert topic_resp.json['name'] == topic['name']
+
+    topic_search_resp = client.get(url_for('api.topic_search'))
+    assert len(topic_search_resp.json['data']) == 1
+    assert topic_search_resp.json['data'][0]['name'] == topic['name']
+    assert topic_search_resp.json['next_page'] is None
+    assert topic_search_resp.json['page'] == 1
+    assert topic_search_resp.json['previous_page'] is None
+    assert topic_search_resp.json['page_size'] == 20
+    assert topic_search_resp.json['total_pages'] == 1
+    assert topic_search_resp.json['total'] == 1
+
+    deletion_resp = client.delete(url_for('api.topic_unindex', topic_id=topic['id']))
+    assert deletion_resp.status_code == 200
+
+    time.sleep(2)
+
+    topic_get_after_delete_resp = client.get(url_for('api.topic_get_specific', topic_id=topic['id']))
+    assert topic_get_after_delete_resp.status_code == 404
+
+    topic_search_after_delete_resp = client.get(url_for('api.topic_search'))
+    assert len(topic_search_after_delete_resp.json['data']) == 0
+    assert topic_search_after_delete_resp.json['next_page'] is None
+    assert topic_search_after_delete_resp.json['page'] == 1
+    assert topic_search_after_delete_resp.json['previous_page'] is None
+    assert topic_search_after_delete_resp.json['page_size'] == 20
+    assert topic_search_after_delete_resp.json['total_pages'] == 1
+    assert topic_search_after_delete_resp.json['total'] == 0
 
 
 def test_api_search_without_query(app, client, search_client, faker):

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 
-from udata_search_service.infrastructure.consumers import ReuseConsumer, OrganizationConsumer, DataserviceConsumer, DatasetConsumer
+from udata_search_service.infrastructure.consumers import ReuseConsumer, OrganizationConsumer, DataserviceConsumer, DatasetConsumer, TopicConsumer
 from udata_search_service.infrastructure.utils import get_concat_title_org, log2p, mdstrip
 
 
@@ -169,6 +169,46 @@ def test_parse_dataservice_obj():
     assert document['organization_name'] == obj['organization']['name']
     assert document['orga_followers'] == log2p(obj['organization']['followers'])
     assert document['description_length'] == log2p(len(mdstrip(obj['description'])))
+
+
+def test_parse_topic_obj():
+    obj = {
+        "id": "683eb313821ff4ee63a1aed3",
+        "name": "Bouquet de test migration xxx",
+        "description": 'Bouquet de test migration\n\n- Thématique Mieux consommer\n- 4 facteurs, 1 pour chaque availabilty\n- 2 groupes, 1 pour "missing" et l\'autre "available"\n- Couverture territoriale Ardennes\n- Organisation DDT Maine et Loire',
+        "tags": ["ecospheres", "ecospheres-theme-mieux-consommer"],
+        # TODO:
+        # "elements": [],
+        "featured": False,
+        "created_at": "2025-06-03T08:32:19.655000+00:00",
+        "geozones": [{"id": "fr:arrondissement:353", "name": "Rennes", "keys": ["353"]},
+                     {"id": "country-group:world"},
+                     {"id": "country:fr"},
+                     {"id": "country-group:ue"}],
+        "granularity": "fr:commune",
+        "last_modified": "2025-06-20T07:24:51.798000+00:00",
+        "organization": {
+            "name": "DDT Maine-et-Loire",
+            "id": "6733676069a129ff84be5753",
+        },
+        "owner": None,
+        "extras": {},
+    }
+    document = TopicConsumer.load_from_dict(copy.deepcopy(obj)).to_dict()
+
+    # Make sure that these fields are loaded as is
+    for key in ["id", "name", "tags", "owner", "featured"]:
+        assert document[key] == obj[key]
+
+    # Make sure that markdown fields are stripped
+    assert document["description"] == mdstrip(obj["description"])
+
+    # Make sure that all other particular fields are treated accordingly
+    assert document["created_at"].date() == datetime.date(2025, 6, 3)
+    assert document["last_modified"].date() == datetime.date(2025, 6, 20)
+    assert document["organization"] == obj["organization"]["id"]
+    assert document["granularity"] == "fr:commune"
+    assert document["geozones"] == ["fr:arrondissement:353", "country-group:world", "country:fr", "country-group:ue"]
 
 
 def test_parse_organization_obj():

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -177,8 +177,7 @@ def test_parse_topic_obj():
         "name": "Bouquet de test migration xxx",
         "description": 'Bouquet de test migration\n\n- Thématique Mieux consommer\n- 4 facteurs, 1 pour chaque availabilty\n- 2 groupes, 1 pour "missing" et l\'autre "available"\n- Couverture territoriale Ardennes\n- Organisation DDT Maine et Loire',
         "tags": ["ecospheres", "ecospheres-theme-mieux-consommer"],
-        # TODO:
-        # "elements": [],
+        "elements_titles": "Titre 1 Titre 2",
         "featured": False,
         "created_at": "2025-06-03T08:32:19.655000+00:00",
         "geozones": [{"id": "fr:arrondissement:353", "name": "Rennes", "keys": ["353"]},

--- a/tests/test_search_client.py
+++ b/tests/test_search_client.py
@@ -1,12 +1,12 @@
 import datetime
 import time
 
-from udata_search_service.domain.factories import DataserviceFactory, DatasetFactory, OrganizationFactory, ReuseFactory
+from udata_search_service.domain.factories import DataserviceFactory, DatasetFactory, OrganizationFactory, ReuseFactory, TopicFactory
 
 ext_word_list = ['abc', 'def', 'hij', 'klm', 'nop', 'qrs', 'tuv']
 
 
-def test_general_search_with_and_without_query(app, client, search_client, faker):
+def test_general_search_with_and_without_query(search_client, faker):
     for i in range(4):
         search_client.index_dataset(DatasetFactory(
             title='test-{0}'.format(i) if i % 2 else faker.word(ext_word_list=ext_word_list),
@@ -24,6 +24,10 @@ def test_general_search_with_and_without_query(app, client, search_client, faker
             title='test-{0}'.format(i) if i % 2 else faker.word(ext_word_list=ext_word_list),
             description='udata' if i == 1 else faker.word()
         ))
+        search_client.index_topic(TopicFactory(
+            name='test-{0}'.format(i) if i % 2 else faker.word(ext_word_list=ext_word_list),
+            description='udata' if i == 1 else faker.word()
+        ))
     # Without this, ElasticSearch does not seem to have the time to index.
     time.sleep(2)
 
@@ -36,6 +40,8 @@ def test_general_search_with_and_without_query(app, client, search_client, faker
     assert results_number == 2
     results_number, res = search_client.query_dataservices('test', 0, 20, {})
     assert results_number == 2
+    results_number, _ = search_client.query_topics('test', 0, 20, {})
+    assert results_number == 2
 
     # Should return only the object with string 'test' and 'udata' in their titles/names or desc
     results_number, res = search_client.query_datasets('test udata', 0, 20, {})
@@ -46,6 +52,8 @@ def test_general_search_with_and_without_query(app, client, search_client, faker
     assert results_number == 1
     results_number, res = search_client.query_dataservices('test udata', 0, 20, {})
     assert results_number == 1
+    results_number, _ = search_client.query_topics('test udata', 0, 20, {})
+    assert results_number == 1
 
     # Should return all objects, as query text is none
     results_number, res = search_client.query_datasets(None, 0, 20, {})
@@ -55,6 +63,8 @@ def test_general_search_with_and_without_query(app, client, search_client, faker
     results_number, res = search_client.query_reuses(None, 0, 20, {})
     assert results_number == 4
     results_number, res = search_client.query_dataservices(None, 0, 20, {})
+    assert results_number == 4
+    results_number, _ = search_client.query_topics(None, 0, 20, {})
     assert results_number == 4
 
 
@@ -94,6 +104,9 @@ def test_search_with_orga_id_filter(app, client, search_client, faker):
     search_client.index_dataservice(DataserviceFactory(
         organization='77f01c346bf99eab7c198891'
     ))
+    search_client.index_topic(TopicFactory(
+        organization='77f01c346bf99eab7c198891'
+    ))
 
     # Without this, ElasticSearch does not seem to have the time to index.
     time.sleep(2)
@@ -107,6 +120,8 @@ def test_search_with_orga_id_filter(app, client, search_client, faker):
     results_number, res = search_client.query_reuses(None, 0, 20, {'organization': '77f01c346bf99eab7c198891'})
     assert results_number == 1
     results_number, res = search_client.query_dataservices(None, 0, 20, {'organization': '77f01c346bf99eab7c198891'})
+    assert results_number == 1
+    results_number, _ = search_client.query_topics(None, 0, 20, {'organization': '77f01c346bf99eab7c198891'})
     assert results_number == 1
 
 
@@ -149,6 +164,10 @@ def test_search_with_owner_filter(app, client, search_client, faker):
         owner='77f01c346bf99eab7c198891'
     ))
 
+    search_client.index_topic(TopicFactory(
+        owner='77f01c346bf99eab7c198891'
+    ))
+
     # Without this, ElasticSearch does not seem to have the time to index.
     time.sleep(2)
 
@@ -161,6 +180,8 @@ def test_search_with_owner_filter(app, client, search_client, faker):
     results_number, res = search_client.query_reuses(None, 0, 20, {'owner': '77f01c346bf99eab7c198891'})
     assert results_number == 1
     results_number, res = search_client.query_dataservices(None, 0, 20, {'owner': '77f01c346bf99eab7c198891'})
+    assert results_number == 1
+    results_number, _ = search_client.query_topics(None, 0, 20, {'owner': '77f01c346bf99eab7c198891'})
     assert results_number == 1
 
 
@@ -201,6 +222,10 @@ def test_search_with_tag_filter(app, client, search_client, faker):
             tags=['test-tag'] if i % 2 else ['not-test-tag']
         ))
 
+        search_client.index_topic(TopicFactory(
+            tags=['test-tag', f'test-tag-{i}'] if i % 2 else ['not-test-tag']
+        ))
+
     # Without this, ElasticSearch does not seem to have the time to index.
     time.sleep(2)
 
@@ -215,6 +240,12 @@ def test_search_with_tag_filter(app, client, search_client, faker):
     results_number, res = search_client.query_reuses(None, 0, 20, {'tags': 'test-tag'})
     assert results_number == 2
     results_number, res = search_client.query_dataservices(None, 0, 20, {'tags': 'test-tag'})
+    assert results_number == 2
+    results_number, _ = search_client.query_topics(None, 0, 20, {})
+    assert results_number == 4
+    results_number, _ = search_client.query_topics(None, 0, 20, {'tags': ['test-tag', 'test-tag-1']})
+    assert results_number == 1
+    results_number, _ = search_client.query_topics(None, 0, 20, {'tags': ['not-test-tag']})
     assert results_number == 2
 
 
@@ -262,6 +293,20 @@ def test_search_dataset_with_geozone_filter(app, client, search_client, faker):
     results_number, res = search_client.query_datasets(None, 0, 20, {'geozones': 'country:fr'})
     assert results_number == 2
 
+def test_search_topic_with_geozone_filter(search_client):
+    for i in range(4):
+        search_client.index_topic(TopicFactory(
+            geozones='country:fr' if i % 2 else 'country:ro'
+        ))
+
+    # Without this, ElasticSearch does not seem to have the time to index.
+    time.sleep(2)
+
+    results_number, _ = search_client.query_topics(None, 0, 20, {})
+    assert results_number == 4
+    results_number, _ = search_client.query_topics(None, 0, 20, {'geozones': 'country:fr'})
+    assert results_number == 2
+
 
 def test_search_dataset_with_granularity_filter(app, client, search_client, faker):
     for i in range(4):
@@ -275,6 +320,21 @@ def test_search_dataset_with_granularity_filter(app, client, search_client, fake
     results_number, res = search_client.query_datasets(None, 0, 20, {})
     assert results_number == 4
     results_number, res = search_client.query_datasets(None, 0, 20, {'granularity': 'country'})
+    assert results_number == 2
+
+
+def test_search_topic_with_granularity_filter(search_client):
+    for i in range(4):
+        search_client.index_topic(TopicFactory(
+            granularity='country' if i % 2 else 'country-subset'
+        ))
+
+    # Without this, ElasticSearch does not seem to have the time to index.
+    time.sleep(2)
+
+    results_number, _ = search_client.query_topics(None, 0, 20, {})
+    assert results_number == 4
+    results_number, _ = search_client.query_topics(None, 0, 20, {'granularity': 'country'})
     assert results_number == 2
 
 
@@ -341,7 +401,7 @@ def test_search_dataservice_with_is_restricted_filter(app, client, search_client
     assert results_number == 2
 
 
-def test_general_search_with_sorting(app, client, search_client, faker):
+def test_general_search_with_sorting(search_client):
     search_client.index_dataset(DatasetFactory(
         title='data-test-1',
         followers=0
@@ -374,6 +434,14 @@ def test_general_search_with_sorting(app, client, search_client, faker):
         title='dataservice-test-2',
         followers=3
     ))
+    search_client.index_topic(TopicFactory(
+        name='a-topic',
+        created_at=datetime.datetime.now(),
+    ))
+    search_client.index_topic(TopicFactory(
+        name='b-topic',
+        created_at=datetime.datetime.now(),
+    ))
     # Without this, ElasticSearch does not seem to have the time to index.
     time.sleep(2)
 
@@ -386,6 +454,8 @@ def test_general_search_with_sorting(app, client, search_client, faker):
     assert res[0]['title'] == 'reuse-test-1'
     results_number, res = search_client.query_dataservices(None, 0, 20, {}, sort='followers')
     assert res[0]['title'] == 'dataservice-test-1'
+    _, res = search_client.query_topics(None, 0, 20, {}, sort='created_at')
+    assert res[0]['name'] == 'a-topic'
 
     # Sort descending
     results_number, res = search_client.query_datasets(None, 0, 20, {}, sort='-followers')
@@ -396,6 +466,8 @@ def test_general_search_with_sorting(app, client, search_client, faker):
     assert res[0]['title'] == 'reuse-test-2'
     results_number, res = search_client.query_dataservices(None, 0, 20, {}, sort='-followers')
     assert res[0]['title'] == 'dataservice-test-2'
+    _, res = search_client.query_topics(None, 0, 20, {}, sort='-created_at')
+    assert res[0]['name'] == 'b-topic'
 
 
 def test_general_search_with_sorting_last_update(app, client, search_client, faker):
@@ -430,3 +502,20 @@ def test_search_dataset_with_synonym(app, client, search_client, faker):
 
     results_number, res = search_client.query_datasets('recensement population', 0, 20, {})
     assert results_number == 1
+
+
+def test_search_topic_with_boolean_filters(search_client):
+    for i in range(4):
+        search_client.index_topic(TopicFactory(
+            featured=bool(i % 2),
+        ))
+
+    # Without this, ElasticSearch does not seem to have the time to index.
+    time.sleep(2)
+
+    results_number, _ = search_client.query_topics(None, 0, 20, {})
+    assert results_number == 4
+    results_number, _ = search_client.query_topics(None, 0, 20, {"featured": True})
+    assert results_number == 2
+    results_number, _ = search_client.query_topics(None, 0, 20, {"featured": False})
+    assert results_number == 2

--- a/udata_search_service/container.py
+++ b/udata_search_service/container.py
@@ -1,5 +1,5 @@
 from dependency_injector import containers, providers
-from udata_search_service.infrastructure.services import DatasetService, OrganizationService, ReuseService, DataserviceService
+from udata_search_service.infrastructure.services import DatasetService, OrganizationService, ReuseService, DataserviceService, TopicService
 from udata_search_service.infrastructure.search_clients import ElasticClient
 
 
@@ -28,5 +28,10 @@ class Container(containers.DeclarativeContainer):
 
     dataservice_service = providers.Factory(
         DataserviceService,
+        search_client=search_client
+    )
+
+    topic_service = providers.Factory(
+        TopicService,
         search_client=search_client
     )

--- a/udata_search_service/domain/entities.py
+++ b/udata_search_service/domain/entities.py
@@ -1,6 +1,6 @@
 import dataclasses
 from typing import List
-from datetime import datetime
+from datetime import date
 from dateutil.parser import isoparse
 
 
@@ -24,14 +24,14 @@ class Organization(EntityBase):
     description: str
     url: str
     orga_sp: int
-    created_at: datetime.date
+    created_at: date
     followers: int
     datasets: int
     views: int
     reuses: int
 
-    badges: List[str] = None
-    acronym: str = None
+    badges: List[str] | None = None
+    acronym: str | None = None
 
     def __post_init__(self):
         if isinstance(self.created_at, str):
@@ -43,7 +43,7 @@ class Dataset(EntityBase):
     id: str
     title: str
     url: str
-    created_at: datetime.date
+    created_at: date
     frequency: str
     format: List[str]
     views: int
@@ -54,24 +54,24 @@ class Dataset(EntityBase):
     concat_title_org: str
     description: str
 
-    last_update: datetime.date = None
-    acronym: str = None
-    badges: List[str] = None
-    tags: List[str] = None
-    license: str = None
-    temporal_coverage_start: datetime.date = None
-    temporal_coverage_end: datetime.date = None
-    granularity: str = None
-    geozones: List[str] = None
-    schema: List[str] = None
-    topics: List[str] = None
+    last_update: date | None = None
+    acronym: str | None = None
+    badges: List[str] | None = None
+    tags: List[str] | None = None
+    license: str | None = None
+    temporal_coverage_start: date | None = None
+    temporal_coverage_end: date | None = None
+    granularity: str | None = None
+    geozones: List[str] | None = None
+    schema: List[str] | None = None
+    topics: List[str] | None = None
 
-    orga_sp: int = None
-    orga_followers: int = None
-    organization: str = None
-    organization_name: str = None
-    organization_badges: List[str] = None
-    owner: str = None
+    orga_sp: int | None = None
+    orga_followers: int | None = None
+    organization: str | None = None
+    organization_name: str | None = None
+    organization_badges: List[str] | None = None
+    owner: str | None = None
 
     def __post_init__(self):
         if isinstance(self.created_at, str):
@@ -89,7 +89,7 @@ class Reuse(EntityBase):
     id: str
     title: str
     url: str
-    created_at: datetime.date
+    created_at: date
     views: int
     followers: int
     datasets: int
@@ -98,13 +98,13 @@ class Reuse(EntityBase):
     type: str
     topic: str
 
-    tags: List[str] = None
-    badges: List[str] = None
-    orga_followers: int = None
-    organization: str = None
-    organization_name: str = None
-    organization_badges: List[str] = None
-    owner: str = None
+    tags: List[str] | None = None
+    badges: List[str] | None = None
+    orga_followers: int | None = None
+    organization: str | None = None
+    organization_name: str | None = None
+    organization_badges: List[str] | None = None
+    owner: str | None = None
 
     def __post_init__(self):
         if isinstance(self.created_at, str):
@@ -117,16 +117,16 @@ class Dataservice(EntityBase):
     title: str
     description: str
     description_length: float
-    created_at: datetime.date
+    created_at: date
 
     views: int = 0
     followers: int = 0
-    is_restricted: bool = None
-    orga_followers: int = None
-    organization: str = None
-    organization_name: str = None
-    owner: str = None
-    tags: List[str] = None
+    is_restricted: bool | None = None
+    orga_followers: int | None = None
+    organization: str | None = None
+    organization_name: str | None = None
+    owner: str | None = None
+    tags: List[str] | None = None
 
     def __post_init__(self):
         if isinstance(self.created_at, str):

--- a/udata_search_service/domain/entities.py
+++ b/udata_search_service/domain/entities.py
@@ -152,6 +152,8 @@ class Topic(EntityBase):
     orga_sp: int | None = None
     orga_followers: int | None = None
 
+    elements_titles: str | None = None
+
     def __post_init__(self):
         if isinstance(self.created_at, str):
             self.created_at = isoparse(self.created_at)

--- a/udata_search_service/domain/entities.py
+++ b/udata_search_service/domain/entities.py
@@ -131,3 +131,29 @@ class Dataservice(EntityBase):
     def __post_init__(self):
         if isinstance(self.created_at, str):
             self.created_at = isoparse(self.created_at)
+
+@dataclasses.dataclass
+class Topic(EntityBase):
+    id: str
+    name: str
+    created_at: date
+    featured: bool
+    featured_score: int
+
+    description: str | None = None
+    owner: str | None = None
+    tags: List[str] | None = None
+    granularity: str | None = None
+    geozones: List[str] | None = None
+    last_modified: date | None = None
+
+    organization: str | None = None
+    organization_name: str | None = None
+    orga_sp: int | None = None
+    orga_followers: int | None = None
+
+    def __post_init__(self):
+        if isinstance(self.created_at, str):
+            self.created_at = isoparse(self.created_at)
+        if isinstance(self.last_modified, str):
+            self.last_modified = isoparse(self.last_modified)

--- a/udata_search_service/domain/factories.py
+++ b/udata_search_service/domain/factories.py
@@ -108,8 +108,9 @@ class TopicFactory(factory.Factory):
     owner = factory.Faker("md5")
     tags = []
     last_modified = factory.LazyFunction(datetime.datetime.utcnow)
-    granularity = factory.Faker('word')
-    geozones = factory.Faker('word')
+    granularity = factory.Faker("word")
+    geozones = factory.Faker("word")
+    elements_titles = factory.Faker("sentence")
 
     @factory.lazy_attribute
     def featured_score(self) -> int:

--- a/udata_search_service/domain/factories.py
+++ b/udata_search_service/domain/factories.py
@@ -1,7 +1,7 @@
 import datetime
 import factory
 
-from udata_search_service.domain.entities import Dataservice, Dataset, Organization, Reuse
+from udata_search_service.domain.entities import Dataservice, Dataset, Organization, Reuse, Topic
 
 
 class DatasetFactory(factory.Factory):
@@ -92,3 +92,25 @@ class DataserviceFactory(factory.Factory):
     organization = factory.Faker('md5')
     organization_name = factory.Faker('company')
     owner = factory.Faker('md5')
+
+
+class TopicFactory(factory.Factory):
+    class Meta:
+        model = Topic
+
+    id = factory.Faker("md5")
+    name = factory.Faker("sentence")
+    description = factory.Faker("text")
+    created_at = factory.LazyFunction(datetime.datetime.utcnow)
+    featured = factory.Faker("boolean")
+    organization = factory.Faker("md5")
+    organization_name = factory.Faker("company")
+    owner = factory.Faker("md5")
+    tags = []
+    last_modified = factory.LazyFunction(datetime.datetime.utcnow)
+    granularity = factory.Faker('word')
+    geozones = factory.Faker('word')
+
+    @factory.lazy_attribute
+    def featured_score(self) -> int:
+        return 4 if self.featured else 1

--- a/udata_search_service/domain/interfaces.py
+++ b/udata_search_service/domain/interfaces.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Tuple, Optional, List
-from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice
+from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice, Topic
 
 
 class SearchClient(ABC):
@@ -30,6 +30,10 @@ class SearchClient(ABC):
         pass
 
     @abstractmethod
+    def index_topic(self, to_index: Topic) -> None:
+        pass
+
+    @abstractmethod
     def query_organizations(self, query_text: str, offset: int, page_size: int) -> Tuple[int, List[Organization]]:
         pass
 
@@ -46,6 +50,10 @@ class SearchClient(ABC):
         pass
 
     @abstractmethod
+    def query_topics(self, query_text: str, offset: int, page_size: int) -> Tuple[int, List[Topic]]:
+        pass
+
+    @abstractmethod
     def find_one_organization(self, organization_id: str) -> Optional[Organization]:
         pass
 
@@ -59,4 +67,8 @@ class SearchClient(ABC):
 
     @abstractmethod
     def find_one_dataservice(self, dataservice_id: str) -> Optional[Dataservice]:
+        pass
+
+    @abstractmethod
+    def find_one_topic(self, topic_id: str) -> Optional[Topic]:
         pass

--- a/udata_search_service/infrastructure/consumers.py
+++ b/udata_search_service/infrastructure/consumers.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice
+from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice, Topic
 from udata_search_service.infrastructure.utils import get_concat_title_org, log2p, mdstrip
 
 
@@ -85,5 +85,24 @@ class DataserviceConsumer(Dataservice):
         data["followers"] = log2p(data.get("followers", 0))
         data["orga_followers"] = log2p(data.get("orga_followers", 0))
         data["description_length"] = log2p(data["description_length"])
+
+        return super().load_from_dict(data)
+
+class TopicConsumer(Topic):
+    @classmethod
+    def load_from_dict(cls, data):
+        # Strip markdown
+        data["description"] = mdstrip(data["description"])
+
+        organization = data["organization"]
+        data["organization"] = organization.get('id') if organization else None
+        data["orga_followers"] = organization.get('followers') if organization else None
+        data["orga_sp"] = organization.get('public_service') if organization else None
+
+        data["geozones"] = [zone.get("id") for zone in data.get("geozones", [])]
+
+        # Normalize values
+        # Use 4 as "on" value for featured, like for datasets
+        data["featured_score"] = 4 if data.get("featured", False) is True else 1
 
         return super().load_from_dict(data)

--- a/udata_search_service/infrastructure/migrate.py
+++ b/udata_search_service/infrastructure/migrate.py
@@ -14,6 +14,7 @@ ALL_INDICES = [
     'reuse',
     'organization',
     'dataservice',
+    'topic',
 ]
 
 

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -471,6 +471,7 @@ class ElasticClient:
                                         "name^15",
                                         "description^8",
                                         "organization_name^8",
+                                        "elements_titles^8",
                                     ],
                                 )
                             ]
@@ -488,6 +489,7 @@ class ElasticClient:
                                         "name^7",
                                         "description^4",
                                         "organization_name^4",
+                                        "elements_titles^4",
                                     ],
                                     operator="and",
                                 )

--- a/udata_search_service/infrastructure/search_clients.py
+++ b/udata_search_service/infrastructure/search_clients.py
@@ -9,7 +9,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import Date, Document, Float, Integer, Keyword, Text, tokenizer, token_filter, analyzer, query
 from elasticsearch_dsl.connections import connections
-from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice
+from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice, Topic
 from udata_search_service.config import Config
 from udata_search_service.infrastructure.utils import IS_TTY
 
@@ -82,6 +82,21 @@ class SearchableDataservice(IndexDocument):
 
     class Index:
         name = f'{Config.UDATA_INSTANCE_NAME}-dataservice'
+
+class SearchableTopic(IndexDocument):
+    name = Text(analyzer=dgv_analyzer)
+    created_at = Date()
+    tags = Keyword(multi=True)
+    organization = Keyword()
+    description = Text(analyzer=dgv_analyzer)
+    organization_name = Text(analyzer=dgv_analyzer)
+    owner = Keyword()
+    granularity = Keyword()
+    geozones = Keyword(multi=True)
+    last_modified = Date()
+
+    class Index:
+        name = f'{Config.UDATA_INSTANCE_NAME}-topic'
 
 
 class SearchableOrganization(IndexDocument):
@@ -175,6 +190,7 @@ class ElasticClient:
         SearchableReuse.init_index(self.es, suffix_name)
         SearchableOrganization.init_index(self.es, suffix_name)
         SearchableDataservice.init_index(self.es, suffix_name)
+        SearchableTopic.init_index(self.es, suffix_name)
 
     def clean_indices(self) -> None:
         '''
@@ -188,20 +204,24 @@ class ElasticClient:
         SearchableReuse.delete_indices(self.es)
         SearchableOrganization.delete_indices(self.es)
         SearchableDataservice.delete_indices(self.es)
+        SearchableTopic.delete_indices(self.es)
 
         self.init_indices()
 
-    def index_organization(self, to_index: Organization, index: str = None) -> None:
+    def index_organization(self, to_index: Organization, index: str | None = None) -> None:
         SearchableOrganization(meta={'id': to_index.id}, **to_index.to_dict()).save(skip_empty=False, index=index)
 
-    def index_dataset(self, to_index: Dataset, index: str = None) -> None:
+    def index_dataset(self, to_index: Dataset, index: str | None = None) -> None:
         SearchableDataset(meta={'id': to_index.id}, **to_index.to_dict()).save(skip_empty=False, index=index)
 
-    def index_reuse(self, to_index: Reuse, index: str = None) -> None:
+    def index_reuse(self, to_index: Reuse, index: str | None = None) -> None:
         SearchableReuse(meta={'id': to_index.id}, **to_index.to_dict()).save(skip_empty=False, index=index)
 
-    def index_dataservice(self, to_index: Dataservice, index: str = None) -> None:
+    def index_dataservice(self, to_index: Dataservice, index: str | None = None) -> None:
         SearchableDataservice(meta={'id': to_index.id}, **to_index.to_dict()).save(skip_empty=False, index=index)
+
+    def index_topic(self, to_index: Topic, index: str | None = None) -> None:
+        SearchableTopic(meta={'id': to_index.id}, **to_index.to_dict()).save(skip_empty=False, index=index)
 
     def query_organizations(self, query_text: str, offset: int, page_size: int, filters: dict, sort: Optional[str] = None) -> Tuple[int, List[dict]]:
         search = SearchableOrganization.search()
@@ -417,6 +437,91 @@ class ElasticClient:
         res = [hit.to_dict(skip_empty=False) for hit in response.hits]
         return results_number, res
 
+    def query_topics(self, query_text: str, offset: int, page_size: int, filters: dict, sort: Optional[str] = None) -> Tuple[int, List[dict]]:
+        search = SearchableTopic.search()
+
+        for key, value in filters.items():
+            if key == 'tags':
+                # build an AND filter from tags list
+                tag_filters = [query.Q('term', tags=tag) for tag in value]
+                search = search.filter(
+                    query.Bool(must=tag_filters)
+                )
+            else:
+                search = search.filter('term', **{key: value})
+
+        topics_score_functions = [
+            query.SF("field_value_factor", field="orga_sp", factor=8, modifier='sqrt', missing=1),
+            query.SF("field_value_factor", field="orga_followers", factor=1, modifier='sqrt', missing=1),
+            query.SF("field_value_factor", field="featured", factor=1, modifier='sqrt', missing=1),
+        ]
+
+        if query_text:
+            search = search.query(
+                "bool",
+                should=[
+                    query.Q(
+                        "function_score",
+                        query=query.Bool(
+                            should=[
+                                query.MultiMatch(
+                                    query=query_text,
+                                    type="phrase",
+                                    fields=[
+                                        "name^15",
+                                        "description^8",
+                                        "organization_name^8",
+                                    ],
+                                )
+                            ]
+                        ),
+                        functions=topics_score_functions,
+                    ),
+                    query.Q(
+                        "function_score",
+                        query=query.Bool(
+                            should=[
+                                query.MultiMatch(
+                                    query=query_text,
+                                    type="cross_fields",
+                                    fields=[
+                                        "name^7",
+                                        "description^4",
+                                        "organization_name^4",
+                                    ],
+                                    operator="and",
+                                )
+                            ]
+                        ),
+                        functions=topics_score_functions,
+                    ),
+                    query.MultiMatch(
+                        query=query_text,
+                        type="most_fields",
+                        operator="and",
+                        fields=["name", "organization_name"],
+                        fuzziness="AUTO:4,6",
+                    ),
+                ],
+            )
+        else:
+            search = search.query(query.Q('function_score', query=query.MatchAll(), functions=topics_score_functions))
+
+        if sort:
+            search = search.sort(sort, {'_score': {'order': 'desc'}})
+
+        search = search[offset:(offset + page_size)]
+
+        response = search.execute()
+        results_number = response.hits.total.value
+        if response.hits and not isinstance(response.hits[0], SearchableTopic):
+            raise ValueError(
+                'Results are not of SearchableTopic type. It probably means that index analyzers were not correctly set '
+                'using template patterns on index initialization.'
+            )
+        res = [hit.to_dict(skip_empty=False) for hit in response.hits]
+        return results_number, res
+
     def find_one_organization(self, organization_id: str) -> Optional[dict]:
         try:
             return SearchableOrganization.get(id=organization_id).to_dict()
@@ -438,6 +543,14 @@ class ElasticClient:
     def find_one_dataservice(self, dataservice_id: str) -> Optional[dict]:
         try:
             return SearchableDataservice.get(id=dataservice_id).to_dict()
+        except NotFoundError:
+            return None
+
+    def find_one_topic(self, topic_id: str) -> Optional[dict]:
+        try:
+            topic = SearchableTopic.get(id=topic_id)
+            if topic:
+                return topic.to_dict()
         except NotFoundError:
             return None
 
@@ -466,5 +579,14 @@ class ElasticClient:
         try:
             SearchableDataservice.get(id=dataservice_id).delete()
             return dataservice_id
+        except NotFoundError:
+            return None
+
+    def delete_one_topic(self, topic_id: str) -> Optional[str]:
+        try:
+            topic = SearchableTopic.get(id=topic_id)
+            if topic:
+                topic.delete()
+                return topic_id
         except NotFoundError:
             return None

--- a/udata_search_service/infrastructure/services.py
+++ b/udata_search_service/infrastructure/services.py
@@ -1,5 +1,5 @@
 from typing import Tuple, Optional, List
-from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice
+from udata_search_service.domain.entities import Dataset, Organization, Reuse, Dataservice, Topic
 from udata_search_service.infrastructure.search_clients import ElasticClient
 
 
@@ -217,4 +217,56 @@ class DataserviceService:
     def format_sort(sort):
         if sort is not None and 'created' in sort:
             sort = sort.replace('created', 'created_at')
+        return sort
+
+
+class TopicService:
+
+    def __init__(self, search_client: ElasticClient):
+        self.search_client = search_client
+
+    def feed(self, topic: Topic, index: str | None = None) -> None:
+        self.search_client.index_topic(topic, index)
+
+    def search(self, filters: dict) -> Tuple[List[Topic], int, int]:
+        page = filters.pop('page')
+        page_size = filters.pop('page_size')
+        search_text = filters.pop('q')
+        sort = self.format_sort(filters.pop('sort', None))
+
+        if page > 1:
+            offset = page_size * (page - 1)
+        else:
+            offset = 0
+
+        self.format_filters(filters)
+
+        results_number, search_results = self.search_client.query_topics(search_text, offset, page_size, filters, sort)
+        results = [Topic.load_from_dict(hit) for hit in search_results]
+        total_pages = round(results_number / page_size) or 1
+        return results, results_number, total_pages
+
+    def find_one(self, topic_id: str) -> Optional[Topic]:
+        try:
+            return Topic.load_from_dict(self.search_client.find_one_topic(topic_id))
+        except TypeError:
+            return None
+
+    def delete_one(self, topic_id: str) -> Optional[str]:
+        return self.search_client.delete_one_topic(topic_id)
+
+    @staticmethod
+    def format_filters(filters):
+        if filters["tag"]:
+            filters["tags"] = filters.pop("tag")
+        if filters["geozone"]:
+            filters["geozones"] = filters.pop("geozone")
+        filtered = {k: v for k, v in filters.items() if v is not None}
+        filters.clear()
+        filters.update(filtered)
+
+    @staticmethod
+    def format_sort(sort):
+        if sort is not None and "created" in sort:
+            sort = sort.replace("created", "created_at")
         return sort

--- a/udata_search_service/presentation/api.py
+++ b/udata_search_service/presentation/api.py
@@ -525,11 +525,12 @@ class TopicToIndex(BaseModel):
     last_modified: str
     featured: bool
     description: str | None = None
-    organization: Optional[dict] = None
-    geozones: Optional[list] = []
-    granularity: Optional[str] = None
-    tags: Optional[list] = []
-    owner: Optional[str] = None
+    organization: dict | None = None
+    geozones: list = []
+    granularity: str | None = None
+    tags: list = []
+    owner: str | None = None
+    elements_titles: str | None = None
 
 
 class RequestTopicIndex(BaseModel):

--- a/udata_search_service/presentation/api.py
+++ b/udata_search_service/presentation/api.py
@@ -6,9 +6,9 @@ from flask import Blueprint, request, url_for, jsonify, abort
 from pydantic import BaseModel, Field, ValidationError, validator
 from udata_search_service.container import Container
 from udata_search_service.config import Config
-from udata_search_service.infrastructure.services import DatasetService, OrganizationService, ReuseService, DataserviceService
+from udata_search_service.infrastructure.services import DatasetService, OrganizationService, ReuseService, DataserviceService, TopicService
 from udata_search_service.infrastructure.search_clients import ElasticClient
-from udata_search_service.infrastructure.consumers import DatasetConsumer, ReuseConsumer, OrganizationConsumer, DataserviceConsumer
+from udata_search_service.infrastructure.consumers import DatasetConsumer, ReuseConsumer, OrganizationConsumer, DataserviceConsumer, TopicConsumer
 from udata_search_service.infrastructure.migrate import set_alias as set_alias_func
 from udata_search_service.presentation.utils import is_list_type
 
@@ -67,7 +67,7 @@ class DatasetArgs(BaseModel):
         ]
         choices = sorts + ['-' + k for k in sorts]
         if value not in choices:
-            raise ValueError('Temporal coverage does not match the right pattern.')
+            raise ValueError('Sort parameter is not in the sorts available choices.')
         return value
 
     @classmethod
@@ -108,7 +108,7 @@ class ReuseArgs(BaseModel):
         ]
         choices = sorts + ['-' + k for k in sorts]
         if value not in choices:
-            raise ValueError('Temporal coverage does not match the right pattern.')
+            raise ValueError('Sort parameter is not in the sorts available choices.')
         return value
 
 
@@ -131,6 +131,45 @@ class DataserviceArgs(BaseModel):
         if value not in choices:
             raise ValueError('Sort parameter is not in the sorts available choices.')
         return value
+
+class TopicArgs(BaseModel):
+    q: Optional[str] = None
+    page: Optional[int] = 1
+    page_size: Optional[int] = 20
+    sort: Optional[str] = None
+    tag: Optional[str] = None
+    organization: Optional[str] = None
+    owner: Optional[str] = None
+    featured: Optional[bool] = None
+    geozone: Optional[str] = None
+    granularity: Optional[str] = None
+
+    @validator('sort')
+    def sort_validate(cls, value):
+        sorts = [
+            'created', 'last_modified'
+        ]
+        choices = sorts + ['-' + k for k in sorts]
+        if value not in choices:
+            raise ValueError('Sort parameter is not in the sorts available choices.')
+        return value
+
+    @classmethod
+    def from_request_args(cls, request_args) -> 'TopicArgs':
+        def get_list_args() -> dict:
+            return {
+                key: value
+                for key, value in request_args.to_dict(flat=False).items()
+                if key in cls.__fields__
+                and is_list_type(cls.__fields__[key].outer_type_)
+            }
+
+        return cls(
+            **{
+                **request_args.to_dict(),
+                **get_list_args(),
+            }
+        )
 
 
 def make_response(results, total_pages, results_number, page, page_size, next_url, prev_url):
@@ -477,6 +516,78 @@ def create_index(search_client: ElasticClient = Provide[Container.search_client]
             logging.error(f'Analyzer was not set using templates when initializing {index_name}')
         return jsonify({'data': f'Index {index_name} created'})
     return jsonify({'data': f'Index {index_name} already exists'})
+
+
+class TopicToIndex(BaseModel):
+    id: str
+    name: str
+    created_at: str
+    last_modified: str
+    featured: bool
+    description: str | None = None
+    organization: Optional[dict] = None
+    geozones: Optional[list] = []
+    granularity: Optional[str] = None
+    tags: Optional[list] = []
+    owner: Optional[str] = None
+
+
+class RequestTopicIndex(BaseModel):
+    document: TopicToIndex
+    index: Optional[str] = None
+
+
+@bp.route("/topics/index", methods=["POST"], endpoint='topic_index')
+@inject
+def topic_index(topic_service: TopicService = Provide[Container.topic_service], search_client: ElasticClient = Provide[Container.search_client]):
+    try:
+        validated_obj = RequestTopicIndex(**request.json)
+    except ValidationError as e:
+        abort(400, e)
+
+    document = TopicConsumer.load_from_dict(validated_obj.document.dict())
+    index_name = f'{Config.UDATA_INSTANCE_NAME}-{validated_obj.index}' if validated_obj.index else None
+    if index_name and not search_client.es.indices.exists(index=index_name):
+        abort(404, 'Index does not exist')
+    topic_service.feed(document, index_name)
+    return jsonify({'data': 'Topic added to index'})
+
+
+@bp.route("/topics/<topic_id>/unindex", methods=["DELETE"], endpoint='topic_unindex')
+@inject
+def topic_unindex(topic_id: str, topic_service: DatasetService = Provide[Container.topic_service]):
+    result = topic_service.delete_one(topic_id)
+    if result:
+        return jsonify({'data': f'Topic {result} removed from index'})
+    abort(404, 'Topic not found')
+
+
+@bp.route("/topics/", methods=["GET"], endpoint='topic_search')
+@inject
+def topics_search(topic_service: TopicService = Provide[Container.topic_service]):
+    try:
+        request_args = TopicArgs.from_request_args(request.args)
+    except ValidationError as e:
+        abort(400, e)
+
+    results, results_number, total_pages = topic_service.search(request_args.dict())
+
+    next_url = url_for('api.topic_search', q=request_args.q, page=request_args.page + 1,
+                       page_size=request_args.page_size, _external=True)
+    prev_url = url_for('api.topic_search', q=request_args.q, page=request_args.page - 1,
+                       page_size=request_args.page_size, _external=True)
+
+    return make_response(results, total_pages, results_number,
+                         request_args.page, request_args.page_size, next_url, prev_url)
+
+
+@bp.route("/topics/<topic_id>/", methods=["GET"], endpoint='topic_get_specific')
+@inject
+def get_topic(topic_id: str, topic_service: TopicService = Provide[Container.topic_service]):
+    result = topic_service.find_one(topic_id)
+    if result:
+        return jsonify(result)
+    abort(404, 'Topic not found')
 
 
 class RequestSetAlias(BaseModel):


### PR DESCRIPTION
Related https://github.com/ecolabdata/ecospheres/issues/580

This adds Topics support to the search service. The Topic search is very similar to the existing objects search. Notable differences:
- `featured` is both a boolean field (for filtering) and a `featured_score` column for scoring
- `elements_titles` is designed to hold a concatenation of the elements titles for the Topic, serialization is done in https://github.com/ecolabdata/udata/pull/4 